### PR TITLE
Fix: Add fallback to NPF video if poster is unavailable

### DIFF
--- a/empati-theme/js/app.js
+++ b/empati-theme/js/app.js
@@ -226,7 +226,7 @@ var app = {
           );
           const { poster } = npfData;
           const markup = `
-            <div class="npf-video-block" style="background-image:url('${poster[0].url}')">
+            <div class="npf-video-block" style="${poster ? `background-image: url(${poster[0].url});` : 'background: rgba(var(--heading-text), 0.25);'}">
               <i class="las la-play"></i>
             </div>
           `;
@@ -588,9 +588,7 @@ var app = {
 
         if (npfData.trail) {
           const postsTrailList = post.querySelectorAll(".reblog-list"); // Get all .reblog-list elements within the current .posts element
-
           postsTrailList.forEach((postsTrail, index) => {
-            console.log('%cPost Trail:', 'background: #00aaaa; color: white', postsTrail);
 
             let trail = npfData.trail[index];
             let trailAskLayout = trail?.layout.find(
@@ -620,8 +618,6 @@ var app = {
             If the blog contains a custom badges
             */
             if (blog.can_show_badges && badges) {
-              //   console.log('%cPost Trail:', 'background: #00aaaa; color: white', postsTrail);
-
               // Check if .reblog-post-badges already exists for this .reblog-list
               let postBadges = postsTrail.querySelector(".reblog-post-badges");
               if (!postBadges) {
@@ -654,7 +650,6 @@ var app = {
                 const trailContent = trail.content[i];
                 switch (trailContent.type) {
                   case "poll":
-                    // console.log(trailContent.created_at);
                     const formattedDate = app.formatDate(
                       trailContent.created_at
                     );


### PR DESCRIPTION
### Description
Fix an issue on #24 where if the grid layout is set and it contains an NPF video block, the popup won't trigger.
The problem appears because it searches for the poster URL, which may be unavailable, leading to an error.

https://github.com/fukou/tumblr-theme/blob/f6273cca63b74ea48394a9dda655a7f9bd1da221/empati-theme/js/app.js#L229

A fallback is required in case the poster video image is unavailable to prevent the error that causes other functions within the JS file to fail.

---

Also deleted some debugging code and other unnecessary code :P